### PR TITLE
[KAIZEN] Sort OpenRpcDocument's methods by name

### DIFF
--- a/core/src/io/iohk/armadillo/JsonRpcEndpointIO.scala
+++ b/core/src/io/iohk/armadillo/JsonRpcEndpointIO.scala
@@ -40,6 +40,10 @@ case class JsonRpcEndpoint[I, E, O](
   def externalDocs(ed: JsonRpcEndpointExternalDocs): JsonRpcEndpoint[I, E, O] = withInfo(info.externalDocs(ed))
 }
 
+object JsonRpcEndpoint {
+  implicit val ordering: Ordering[JsonRpcEndpoint[_, _, _]] = Ordering.by(_.methodName.asString)
+}
+
 case class JsonRpcEndpointInfo(
     summary: Option[String],
     description: Option[String],

--- a/openrpc/src/io/iohk/armadillo/openrpc/OpenRpcDocsInterpreter.scala
+++ b/openrpc/src/io/iohk/armadillo/openrpc/OpenRpcDocsInterpreter.scala
@@ -6,15 +6,17 @@ import sttp.tapir.Schema
 
 case class OpenRpcDocsInterpreter(markOptionsAsNullable: Boolean = true) {
   def toOpenRpc(info: OpenRpcInfo, endpoints: List[AnyEndpoint]): OpenRpcDocument = {
+    val sortedEndpoints = endpoints.sorted
+
     val toNamedSchemas = new ToNamedSchemas
     val (keyToSchema, schemas) =
-      new SchemaForEndpoints(endpoints, toNamedSchemas, markOptionsAsNullable).calculate()
+      new SchemaForEndpoints(sortedEndpoints, toNamedSchemas, markOptionsAsNullable).calculate()
 
     val methodCreator = new EndpointToOpenRpcMethods(schemas)
 
     OpenRpcDocument(
       info = info,
-      methods = RequiredList(methodCreator.methods(endpoints)),
+      methods = RequiredList(methodCreator.methods(sortedEndpoints)),
       components = if (keyToSchema.nonEmpty) Some(OpenRpcComponents(List.empty, keyToSchema.sortByKey)) else None
     )
   }

--- a/openrpc/test/resources/sorted_basic_empty.json
+++ b/openrpc/test/resources/sorted_basic_empty.json
@@ -1,0 +1,39 @@
+{
+  "openrpc": "1.2.1",
+  "info": {
+    "version": "1.0.0",
+    "title": "Demo Pet Store"
+  },
+  "methods": [
+    {
+      "name": "empty",
+      "params": [
+      ],
+      "result": {
+        "name": "empty result",
+        "schema": {
+          
+        }
+      }
+    },
+    {
+      "name": "hello",
+      "params": [
+        {
+          "name": "param1",
+          "required": true,
+          "schema": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      ],
+      "result": {
+        "name": "response",
+        "schema": {
+          "type": "string"
+        }
+      }
+    }
+  ]
+}

--- a/openrpc/test/src/io/iohk/armadillo/openrpc/VerifyJsonTest.scala
+++ b/openrpc/test/src/io/iohk/armadillo/openrpc/VerifyJsonTest.scala
@@ -15,6 +15,16 @@ object VerifyJsonTest extends SimpleIOSuite {
 
   compare("basic.json", OpenRpcDocsInterpreter().toOpenRpc(PetStoreInfo, List(basic)))
   compare("empty.json", OpenRpcDocsInterpreter().toOpenRpc(PetStoreInfo, List(empty)))
+  compare("sorted_basic_empty.json", OpenRpcDocsInterpreter().toOpenRpc(PetStoreInfo, List(basic, empty)))
+
+  test("OpenRpcDocument's methods are ordered") {
+    IO.pure(
+      expect.same(
+        OpenRpcDocsInterpreter().toOpenRpc(PetStoreInfo, List(empty, basic)),
+        OpenRpcDocsInterpreter().toOpenRpc(PetStoreInfo, List(basic, empty))
+      )
+    )
+  }
 
   private def compare(file: String, document: OpenRpcDocument): Unit = {
     test(file) {


### PR DESCRIPTION
Make sure that methods will be displayed in alphanumerical order. By doing so, it will be easier to search for a specific method.