### PR TITLE
Add dependabot and scala-steward, and update dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: daily
+      time: "00:00"
+      timezone: UTC
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore"
+      include: "scope"

--- a/.github/workflows/scala-steward.yml
+++ b/.github/workflows/scala-steward.yml
@@ -1,0 +1,25 @@
+name: Scala Steward
+
+# This workflow will launch at 00:00 every day
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  scala-steward:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: coursier/cache-action@v6
+      - uses: coursier/setup-action@v1.3.0
+        with:
+          jvm: adopt:11
+      - name: Launch Scala Steward
+        uses: scala-steward-org/scala-steward-action@v2
+        with:
+          author-name: scala-steward
+          author-email: scala-steward
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-config: .scala-steward.conf
+          ignore-opts-files: false

--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,0 +1,3 @@
+updates.ignore = [
+  {groupId = "org.scala-lang", artifactId = "scala-compiler", version = "2.13."}
+]

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,3 +1,3 @@
-version = 3.5.3
+version = 3.6.1
 maxColumn = 140
 runner.dialect = scala213

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ BlazeServerBuilder[IO]
   .withHttpApp(Router("/" -> routes).orNotFound)
   .resource
   .flatMap { _ =>
-    AsyncHttpClientCatsBackend.resource[IO]()
+    ArmeriaCatsBackend.resource[IO]()
   }
   .use { client =>
     val request = json"""{"jsonrpc": "2.0", "method": "say_hello", "params": ["kasper"], "id": 1}"""

--- a/build.sc
+++ b/build.sc
@@ -56,7 +56,7 @@ object openrpc extends CommonModule with ArmadilloPublishModule {
   object circeYaml extends CommonModule with ArmadilloPublishModule {
     override def moduleDeps = Seq(circe)
 
-    override def ivyDeps = Agg(ivy"io.circe::circe-yaml::${Version.Circe}")
+    override def ivyDeps = Agg(ivy"io.circe::circe-yaml::${Version.CirceYaml}")
   }
 
   override def moduleDeps = Seq(core, circeYaml)
@@ -89,8 +89,8 @@ object server extends CommonModule with ArmadilloPublishModule {
         ivy"com.softwaremill.sttp.tapir::tapir-http4s-server::${Version.Tapir}",
         ivy"com.softwaremill.sttp.tapir::tapir-cats::${Version.Tapir}",
         ivy"com.softwaremill.sttp.tapir::tapir-sttp-client::${Version.Tapir}",
-        ivy"com.softwaremill.sttp.client3::async-http-client-backend-cats::${Version.Sttp}",
-        ivy"org.http4s::http4s-blaze-server::${Version.Http4s}",
+        ivy"com.softwaremill.sttp.client3::armeria-backend-cats::${Version.Sttp}",
+        ivy"org.http4s::http4s-blaze-server::${Version.Http4sBlazeServer}",
         ivy"com.softwaremill.sttp.client3::circe::${Version.Sttp}",
         ivy"org.typelevel::cats-effect::${Version.CatsEffect}"
       )
@@ -100,7 +100,7 @@ object server extends CommonModule with ArmadilloPublishModule {
   object fs2 extends CommonModule with ArmadilloPublishModule {
     override def moduleDeps = Seq(core, json.circe, server)
     override def ivyDeps = Agg(
-      ivy"co.fs2::fs2-core::3.2.5",
+      ivy"co.fs2::fs2-core::${Version.Fs2}",
       ivy"com.softwaremill.sttp.tapir::tapir-cats::${Version.Tapir}"
     )
   }
@@ -145,14 +145,14 @@ object example extends CommonModule {
         ivy"org.typelevel::cats-effect::${Version.CatsEffect}",
         ivy"org.http4s::http4s-dsl::${Version.Http4s}",
         ivy"org.http4s::http4s-circe::${Version.Http4s}",
-        ivy"org.http4s::http4s-blaze-server::${Version.Http4s}",
+        ivy"org.http4s::http4s-blaze-server::${Version.Http4sBlazeServer}",
         ivy"com.softwaremill.sttp.tapir::tapir-http4s-server::${Version.Tapir}",
         ivy"com.softwaremill.sttp.tapir::tapir-cats::${Version.Tapir}",
         ivy"org.json4s::json4s-core::${Version.Json4s}",
         ivy"org.json4s::json4s-jackson:${Version.Json4s}",
-        ivy"ch.qos.logback:logback-classic:1.2.7",
+        ivy"ch.qos.logback:logback-classic:${Version.Logback}",
         ivy"com.softwaremill.sttp.tapir::tapir-sttp-client::${Version.Tapir}",
-        ivy"com.softwaremill.sttp.client3::async-http-client-backend-cats::${Version.Sttp}"
+        ivy"com.softwaremill.sttp.client3::armeria-backend-cats::${Version.Sttp}"
       )
   }
   object circeApp extends CommonModule {
@@ -163,12 +163,12 @@ object example extends CommonModule {
         ivy"org.typelevel::cats-effect::${Version.CatsEffect}",
         ivy"org.http4s::http4s-dsl::${Version.Http4s}",
         ivy"org.http4s::http4s-circe::${Version.Http4s}",
-        ivy"org.http4s::http4s-blaze-server::${Version.Http4s}",
+        ivy"org.http4s::http4s-blaze-server::${Version.Http4sBlazeServer}",
         ivy"com.softwaremill.sttp.tapir::tapir-http4s-server::${Version.Tapir}",
         ivy"com.softwaremill.sttp.tapir::tapir-cats::${Version.Tapir}",
-        ivy"ch.qos.logback:logback-classic:1.2.7",
+        ivy"ch.qos.logback:logback-classic:${Version.Logback}",
         ivy"com.softwaremill.sttp.tapir::tapir-sttp-client::${Version.Tapir}",
-        ivy"com.softwaremill.sttp.client3::async-http-client-backend-cats::${Version.Sttp}",
+        ivy"com.softwaremill.sttp.client3::armeria-backend-cats::${Version.Sttp}",
         ivy"io.circe::circe-literal::${Version.Circe}"
       )
   }
@@ -179,39 +179,38 @@ object example extends CommonModule {
       Agg(
         ivy"org.typelevel::cats-effect::${Version.CatsEffect}",
         ivy"org.http4s::http4s-dsl::${Version.Http4s}",
-        ivy"org.http4s::http4s-blaze-server::${Version.Http4s}",
+        ivy"org.http4s::http4s-blaze-server::${Version.Http4sBlazeServer}",
         ivy"com.softwaremill.sttp.tapir::tapir-http4s-server::${Version.Tapir}",
         ivy"com.softwaremill.sttp.tapir::tapir-cats::${Version.Tapir}",
         ivy"org.json4s::json4s-core::${Version.Json4s}",
         ivy"org.json4s::json4s-jackson:${Version.Json4s}",
-        ivy"io.janstenpickle::trace4cats-log-exporter::${Version.Trace4cats}",
-        ivy"io.janstenpickle::trace4cats-avro-exporter::${Version.Trace4cats}",
-        ivy"ch.qos.logback:logback-classic:1.2.7",
+        ivy"io.janstenpickle::trace4cats-core::${Version.Trace4cats}",
+        ivy"ch.qos.logback:logback-classic:${Version.Logback}",
         ivy"com.softwaremill.sttp.tapir::tapir-sttp-client::${Version.Tapir}",
-        ivy"com.softwaremill.sttp.client3::async-http-client-backend-cats::${Version.Sttp}"
+        ivy"com.softwaremill.sttp.client3::armeria-backend-cats::${Version.Sttp}"
       )
   }
   object circeFs2 extends CommonModule {
     override def moduleDeps = Seq(core, server.fs2, json.circe)
     override def ivyDeps = Agg(
-      ivy"co.fs2::fs2-core::3.2.5",
-      ivy"co.fs2::fs2-io::3.2.5",
+      ivy"co.fs2::fs2-core::${Version.Fs2}",
+      ivy"co.fs2::fs2-io::${Version.Fs2}",
       ivy"com.softwaremill.sttp.tapir::tapir-cats::${Version.Tapir}",
-      ivy"com.github.jnr:jnr-unixsocket:0.38.8"
+      ivy"com.github.jnr:jnr-unixsocket:0.38.19"
     )
   }
 
-  object tapirWebsocket extends CommonModule{
+  object tapirWebsocket extends CommonModule {
     override def moduleDeps = Seq(core, server.fs2, json.circe, server.tapir)
     override def ivyDeps = Agg(
-      ivy"co.fs2::fs2-core::3.2.5",
+      ivy"co.fs2::fs2-core::${Version.Fs2}",
       ivy"org.typelevel::cats-effect::${Version.CatsEffect}",
       ivy"org.http4s::http4s-dsl::${Version.Http4s}",
       ivy"org.http4s::http4s-circe::${Version.Http4s}",
-      ivy"org.http4s::http4s-blaze-server::${Version.Http4s}",
+      ivy"org.http4s::http4s-blaze-server::${Version.Http4sBlazeServer}",
       ivy"com.softwaremill.sttp.tapir::tapir-http4s-server::${Version.Tapir}",
       ivy"com.softwaremill.sttp.tapir::tapir-cats::${Version.Tapir}",
-      ivy"ch.qos.logback:logback-classic:1.2.7",
+      ivy"ch.qos.logback:logback-classic:${Version.Logback}",
       ivy"com.softwaremill.sttp.tapir::tapir-sttp-client::${Version.Tapir}",
       ivy"com.softwaremill.sttp.client3::async-http-client-backend-fs2::${Version.Sttp}",
       ivy"io.circe::circe-literal::${Version.Circe}"
@@ -222,15 +221,14 @@ object example extends CommonModule {
 object trace4cats extends CommonModule with ArmadilloPublishModule {
   override def moduleDeps = Seq(core)
   override def ivyDeps = Agg(
-    ivy"io.janstenpickle::trace4cats-base::${Version.Trace4cats}",
+    ivy"io.janstenpickle::trace4cats-kernel::${Version.Trace4cats}",
     ivy"io.janstenpickle::trace4cats-core::${Version.Trace4cats}",
-    ivy"io.janstenpickle::trace4cats-inject::${Version.Trace4cats}",
     ivy"com.softwaremill.sttp.tapir::tapir-cats::${Version.Tapir}"
   )
 }
 
 trait BaseModule extends ScalaModule with ScalafmtModule with TpolecatModule with ScalafixModule with ScalaMetalsSupport {
-  override def semanticDbVersion = "4.4.32"
+  override def semanticDbVersion = T.input { "4.4.32" }
   override def scalafixScalaBinaryVersion = "2.13"
   override def scalacOptions = T {
     super.scalacOptions().filterNot(Set("-Xfatal-warnings", "-Xsource:3")) ++ Seq(
@@ -243,7 +241,7 @@ trait BaseModule extends ScalaModule with ScalafmtModule with TpolecatModule wit
 }
 
 trait CommonTestModule extends BaseModule with TestModule {
-  val WeaverDep = ivy"com.disneystreaming::weaver-cats:0.7.11"
+  val WeaverDep = ivy"com.disneystreaming::weaver-cats:0.8.1"
 
   override def ivyDeps = Agg(WeaverDep)
   override def testFramework = "weaver.framework.CatsEffect"
@@ -278,12 +276,16 @@ trait ArmadilloPublishModule extends PublishModule {
 }
 
 object Version {
-  val Trace4cats = "0.13.1"
-  val Tapir = "1.1.2"
-  val Http4s = "0.23.10"
+  val Trace4cats = "0.14.1"
+  val Tapir = "1.2.3"
+  val Http4s = "0.23.16"
+  val Http4sBlazeServer = "0.23.12"
   val Json4s = "4.0.6"
-  val Circe = "0.14.1"
-  val Sttp = "3.8.2"
-  val CatsEffect = "3.3.12"
+  val Circe = "0.14.3"
+  val CirceYaml = "0.14.2"
+  val Sttp = "3.8.5"
+  val CatsEffect = "3.4.2"
   val Apispec = "0.3.1"
+  val Fs2 = "3.4.0"
+  val Logback = "1.4.5"
 }

--- a/example/circeApp/src/io/iohk/armadillo/example/ExampleCirce.scala
+++ b/example/circeApp/src/io/iohk/armadillo/example/ExampleCirce.scala
@@ -11,7 +11,7 @@ import io.iohk.armadillo.server._
 import io.iohk.armadillo.server.tapir.TapirInterpreter
 import org.http4s.blaze.server.BlazeServerBuilder
 import org.http4s.server.Router
-import sttp.client3.asynchttpclient.cats.AsyncHttpClientCatsBackend
+import sttp.client3.armeria.cats.ArmeriaCatsBackend
 import sttp.model.{StatusCode, Uri}
 import sttp.monad.MonadError
 import sttp.tapir.integ.cats._
@@ -58,7 +58,7 @@ object ExampleCirce extends IOApp {
       .withHttpApp(Router("/" -> routes).orNotFound)
       .resource
       .flatMap { _ =>
-        AsyncHttpClientCatsBackend.resource[IO]()
+        ArmeriaCatsBackend.resource[IO]()
       }
       .use { client =>
         val sttpClient = SttpClientInterpreter().toClient(tapirEndpoints.endpoint, Some(Uri.apply("localhost", 8545)), client)

--- a/example/json4sAndTrace4cats/src/io/iohk/armadillo/example/ExampleTraced.scala
+++ b/example/json4sAndTrace4cats/src/io/iohk/armadillo/example/ExampleTraced.scala
@@ -1,5 +1,8 @@
 package io.iohk.armadillo.example
 
+import _root_.trace4cats.context.Provide
+import _root_.trace4cats.log.LogSpanCompleter
+import _root_.trace4cats.{EntryPoint, Span, SpanSampler, Trace, TraceProcess}
 import cats.Applicative
 import cats.data.Kleisli
 import cats.effect.kernel.{MonadCancelThrow, Resource, Sync}
@@ -8,12 +11,6 @@ import io.iohk.armadillo.json.json4s._
 import io.iohk.armadillo.server.tapir.TapirInterpreter
 import io.iohk.armadillo.trace4cats.syntax._
 import io.iohk.armadillo.{JsonRpcServerEndpoint, _}
-import io.janstenpickle.trace4cats.Span
-import io.janstenpickle.trace4cats.base.context.Provide
-import io.janstenpickle.trace4cats.inject.{EntryPoint, Trace}
-import io.janstenpickle.trace4cats.kernel.SpanSampler
-import io.janstenpickle.trace4cats.log.LogSpanCompleter
-import io.janstenpickle.trace4cats.model.TraceProcess
 import org.http4s.blaze.server.BlazeServerBuilder
 import org.http4s.server.Router
 import org.json4s.{Formats, JValue, NoTypeHints, Serialization}

--- a/server/tapir/test/src/io/iohk/armadillo/server/tapir/http4s/BaseSuite.scala
+++ b/server/tapir/test/src/io/iohk/armadillo/server/tapir/http4s/BaseSuite.scala
@@ -11,7 +11,7 @@ import io.iohk.armadillo.server.{AbstractCirceSuite, CirceEndpoints}
 import org.http4s.HttpRoutes
 import org.http4s.blaze.server.BlazeServerBuilder
 import org.http4s.server.Router
-import sttp.client3.asynchttpclient.cats.AsyncHttpClientCatsBackend
+import sttp.client3.armeria.cats.ArmeriaCatsBackend
 import sttp.client3.circe._
 import sttp.client3.{DeserializationException, HttpError, StringBody, SttpBackend, basicRequest}
 import sttp.model.{MediaType, StatusCode, Uri}
@@ -211,7 +211,7 @@ trait BaseSuite extends AbstractCirceSuite[StringBody, ServerEndpoint[Any, IO]] 
       .resource
       .map(_.address.getPort)
       .flatMap { port =>
-        AsyncHttpClientCatsBackend.resource[IO]().map { backend =>
+        ArmeriaCatsBackend.resource[IO]().map { backend =>
           import sttp.model.Uri._
           (backend, uri"http://localhost:$port")
         }

--- a/trace4cats/src/io/iohk/armadillo/trace4cats/ArmadilloResourceKleislis.scala
+++ b/trace4cats/src/io/iohk/armadillo/trace4cats/ArmadilloResourceKleislis.scala
@@ -3,9 +3,9 @@ package io.iohk.armadillo.trace4cats
 import cats.Monad
 import cats.data.{EitherT, Kleisli}
 import cats.effect.kernel.Resource
-import io.janstenpickle.trace4cats.inject.{ResourceKleisli, SpanParams}
-import io.janstenpickle.trace4cats.model.{SpanKind, TraceHeaders}
-import io.janstenpickle.trace4cats.{ErrorHandler, Span}
+import trace4cats.kernel.ErrorHandler
+import trace4cats.model.{SpanKind, TraceHeaders}
+import trace4cats.{ResourceKleisli, Span, SpanParams}
 
 object ArmadilloResourceKleislis {
   def fromInput[F[_], I](

--- a/trace4cats/src/io/iohk/armadillo/trace4cats/ArmadilloStatusMapping.scala
+++ b/trace4cats/src/io/iohk/armadillo/trace4cats/ArmadilloStatusMapping.scala
@@ -1,6 +1,6 @@
 package io.iohk.armadillo.trace4cats
 
-import io.janstenpickle.trace4cats.model.SpanStatus
+import trace4cats.SpanStatus
 
 object ArmadilloStatusMapping {
   def errorStringToInternal[E]: ArmadilloStatusMapping[E] = e => SpanStatus.Internal(e.toString)

--- a/trace4cats/src/io/iohk/armadillo/trace4cats/ServerEndpointSyntax.scala
+++ b/trace4cats/src/io/iohk/armadillo/trace4cats/ServerEndpointSyntax.scala
@@ -4,9 +4,8 @@ import cats.Monad
 import cats.effect.kernel.MonadCancelThrow
 import cats.syntax.either._
 import io.iohk.armadillo.JsonRpcServerEndpoint
-import io.janstenpickle.trace4cats.Span
-import io.janstenpickle.trace4cats.base.context.Provide
-import io.janstenpickle.trace4cats.inject.{EntryPoint, ResourceKleisli, Trace}
+import trace4cats.context.Provide
+import trace4cats.{EntryPoint, ResourceKleisli, Span, Trace}
 
 trait ServerEndpointSyntax {
   implicit class TracedServerEndpoint[I, E, O, F[_], G[_]](

--- a/trace4cats/src/io/iohk/armadillo/trace4cats/ServerEndpointTracer.scala
+++ b/trace4cats/src/io/iohk/armadillo/trace4cats/ServerEndpointTracer.scala
@@ -4,9 +4,9 @@ import cats.Monad
 import cats.data.EitherT
 import cats.effect.kernel.MonadCancelThrow
 import io.iohk.armadillo.JsonRpcServerEndpoint
-import io.janstenpickle.trace4cats.base.context.Provide
-import io.janstenpickle.trace4cats.inject.{ResourceKleisli, Trace}
 import sttp.tapir.integ.cats.MonadErrorSyntax._
+import trace4cats.context.Provide
+import trace4cats.{ResourceKleisli, Trace}
 
 object ServerEndpointTracer {
   def inject[I, E, O, F[_], G[_], Ctx](

--- a/trace4cats/src/io/iohk/armadillo/trace4cats/package.scala
+++ b/trace4cats/src/io/iohk/armadillo/trace4cats/package.scala
@@ -1,10 +1,9 @@
 package io.iohk.armadillo
 
-import io.janstenpickle.trace4cats.inject.SpanName
-import io.janstenpickle.trace4cats.model.SpanStatus
+import _root_.trace4cats.SpanStatus
 
 package object trace4cats {
-  type ArmadilloSpanNamer[I] = (JsonRpcEndpoint[I, _, _], I) => SpanName
-  type ArmadilloInputSpanNamer[I] = I => SpanName
+  type ArmadilloSpanNamer[I] = (JsonRpcEndpoint[I, _, _], I) => String
+  type ArmadilloInputSpanNamer[I] = I => String
   type ArmadilloStatusMapping[E] = E => SpanStatus
 }


### PR DESCRIPTION
This PR aims to add dependabot and scala-steward.

Dependencies have been updated as well, which leads to deprecated code. So:
- `AsyncHttpClientCatsBackend` has been replaced by `ArmeriaCatsBackend`
- `SpanName` has been replaced by `String`

I choose to use `_root_` as there was a conflict with package `trace4cats` which is defined in both trace4cats library (used to be `io.janstenpickle.trace4cats`) and in Armadillo.
Another solution would be to rename the package in Armadillo.