### PR TITLE
Add possibility to use OpenAPi 3.0 for generating openrpc specification in yaml

### DIFF
--- a/openrpc/circeYaml/src/io/iohk/armadillo/openrpc/circe/yaml/ArmadilloOpenRpcCirceYaml.scala
+++ b/openrpc/circeYaml/src/io/iohk/armadillo/openrpc/circe/yaml/ArmadilloOpenRpcCirceYaml.scala
@@ -1,12 +1,13 @@
 package io.iohk.armadillo.openrpc.circe.yaml
 
+import io.circe.Encoder
 import io.circe.syntax._
 import io.circe.yaml.Printer
-import io.iohk.armadillo.openrpc.circe._
 import io.iohk.armadillo.openrpc.model.OpenRpcDocument
 
 trait ArmadilloOpenRpcCirceYaml {
   implicit class RichOpenRpcDocument(document: OpenRpcDocument) {
-    def toYaml: String = Printer(dropNullKeys = true, preserveOrder = true).pretty(document.asJson)
+    def toYaml(implicit documentEncoder: Encoder[OpenRpcDocument]): String =
+      Printer(dropNullKeys = true, preserveOrder = true).pretty(document.asJson(documentEncoder))
   }
 }

--- a/openrpc/test/src/io/iohk/armadillo/openrpc/VerifyYamlTest.scala
+++ b/openrpc/test/src/io/iohk/armadillo/openrpc/VerifyYamlTest.scala
@@ -4,6 +4,7 @@ import cats.effect.IO
 import io.iohk.armadillo._
 import io.iohk.armadillo.openrpc.Basic._
 import io.iohk.armadillo.openrpc.TestUtils.{load, noIndentation}
+import io.iohk.armadillo.openrpc.circe._
 import io.iohk.armadillo.openrpc.circe.yaml._
 import io.iohk.armadillo.openrpc.model.{OpenRpcDocument, OpenRpcInfo}
 import weaver.SimpleIOSuite


### PR DESCRIPTION
## Description
This PR aims to enable the usage of OpenAPI v3.0 for yaml.

Currently, it's already possible to use the version 3.0 of OpenAPI, but only when generating specification as Json:
```
case object CustomArmadilloOpenRpcCirce extends ArmadilloOpenRpcCirce {
  override val anyObjectEncoding: AnySchema.Encoding = AnySchema.Encoding.Boolean
  override def openApi30: Boolean = true
}

import CustomArmadilloOpenRpcCirce._ // Instead of import io.iohk.armadillo.openrpc.circe._

val document: OpenRpcDocument = ???
println(document.asJson) // OpenAPI 3.0
println(document.asYaml) // OpenAPI 3.1, because it's using import io.iohk.armadillo.openrpc.circe._
```
